### PR TITLE
Fix non-admin scan failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+    - "**"
   pull_request:
     branches: [ main ]
 
@@ -23,5 +24,5 @@ jobs:
     - name: Build project
       run: just build
 
-    - name: Run tests
+    - name: Run unit and UI tests
       run: just test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,15 @@
 # AppDetective Agent Guidelines
 
 ## CI/CD
-- **GitHub Actions**: CI workflow runs on push/PR to main branch
+- **GitHub Actions**: CI workflow runs on branch pushes and PRs to main
 - **Platforms**: macOS 26
-- **Steps**: Checkout, build Debug, run unit tests, validate app bundle
+- **Steps**: Checkout, build Debug, run unit/UI tests, validate app bundle
 
-## Git Workflow
-- **Branching**: Always create a new branch for each task or feature before starting work.
-- **Commits**: Always propose a draft commit message and ask for user confirmation before committing.
-- **Pushing**: Never push changes to the remote repository without explicit user request.
+## Jujutsu Workflow
+- **Tooling**: Use Jujutsu (`jj`) for local version control. The Git checkout may appear as detached `HEAD`; this is expected.
+- **Task Changes**: Always start from a fresh `jj` change for each task or feature before editing. Use a bookmark when a named branch is needed for sharing or pushing.
+- **Descriptions**: Always propose a draft change description/commit message and ask for user confirmation before finalizing it.
+- **Pushing**: Never push bookmarks or changes to the remote repository without explicit user request.
 
 ## Build Commands
 - **Build**: `xcodebuild -project AppDetective/AppDetective.xcodeproj -scheme AppDetective build | xcbeautify`

--- a/AppDetective/AppDetective/App/LaunchArguments.swift
+++ b/AppDetective/AppDetective/App/LaunchArguments.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+enum LaunchArguments {
+    static let scanFolder = "--scan-folder"
+
+    static var startupFolderURL: URL? {
+        startupFolderURL(from: ProcessInfo.processInfo.arguments)
+    }
+
+    static func startupFolderURL(from arguments: [String]) -> URL? {
+        if let flaggedPath = pathValue(for: scanFolder, in: arguments) {
+            return folderURL(from: flaggedPath)
+        }
+
+        return positionalPath(in: arguments).map(folderURL)
+    }
+
+    private static func pathValue(for option: String, in arguments: [String]) -> String? {
+        if let inlineArgument = arguments.first(where: { $0.hasPrefix("\(option)=") }) {
+            let value = String(inlineArgument.dropFirst(option.count + 1))
+            return validPathValue(value)
+        }
+
+        guard
+            let argumentIndex = arguments.firstIndex(of: option),
+            arguments.indices.contains(argumentIndex + 1)
+        else {
+            return nil
+        }
+
+        return validPathValue(arguments[argumentIndex + 1])
+    }
+
+    private static func validPathValue(_ value: String) -> String? {
+        guard !value.isEmpty, !value.hasPrefix("-") else {
+            return nil
+        }
+
+        return value
+    }
+
+    private static func positionalPath(in arguments: [String]) -> String? {
+        var shouldSkipNextArgument = false
+
+        for argument in arguments.dropFirst() {
+            if shouldSkipNextArgument {
+                shouldSkipNextArgument = false
+                continue
+            }
+
+            if argument == "-ApplePersistenceIgnoreState" || argument == scanFolder {
+                shouldSkipNextArgument = true
+                continue
+            }
+
+            if argument.hasPrefix("\(scanFolder)=") || argument.hasPrefix("-") {
+                continue
+            }
+
+            return argument
+        }
+
+        return nil
+    }
+
+    private static func folderURL(from path: String) -> URL {
+        URL(
+            fileURLWithPath: (path as NSString).expandingTildeInPath,
+            isDirectory: true
+        )
+    }
+}

--- a/AppDetective/AppDetective/AppDetectiveApp.swift
+++ b/AppDetective/AppDetective/AppDetectiveApp.swift
@@ -1,17 +1,27 @@
+import Foundation
 import SwiftUI
 
 @main
 struct AppDetectiveApp: App {
     @AppStorage("selectedFolderBookmark") private var selectedFolderBookmark: Data?
-    @StateObject private var contentViewModel = ContentViewModel()
+    @StateObject private var contentViewModel: ContentViewModel
     @StateObject private var updater = SparkleUpdater()
-    @State private var isResolvingBookmark: Bool = true
+    @State private var isResolvingBookmark: Bool
+    private let startupFolderURL: URL?
+
+    init() {
+        let startupFolderURL = LaunchArguments.startupFolderURL
+        self.startupFolderURL = startupFolderURL
+        _contentViewModel = StateObject(wrappedValue: ContentViewModel(folderURL: startupFolderURL))
+        _isResolvingBookmark = State(initialValue: startupFolderURL == nil)
+    }
 
     var body: some Scene {
         WindowGroup {
             Group {
                 if isResolvingBookmark {
-                    Spacer()
+                    ProgressView()
+                        .frame(minWidth: 500, minHeight: 400)
                 } else {
                     Group {
                         if contentViewModel.folderURL != nil {
@@ -30,12 +40,15 @@ struct AppDetectiveApp: App {
                 }
             }
             .onAppear {
+                guard startupFolderURL == nil else { return }
                 resolveBookmark()
             }
             .onChange(of: selectedFolderBookmark) { _, _ in
+                guard startupFolderURL == nil else { return }
                 resolveBookmark()
             }
             .onChange(of: contentViewModel.folderURL) { _, newURL in
+                guard startupFolderURL == nil else { return }
                 if let urlToSave = newURL {
                     do {
                         let newBookmarkData = try urlToSave.bookmarkData(options: .withSecurityScope, includingResourceValuesForKeys: nil, relativeTo: nil)
@@ -67,7 +80,9 @@ struct AppDetectiveApp: App {
                 .disabled(!updater.canCheckForUpdates)
                 Divider()
                 Button {
-                    AppDetectiveApp.installCLI()
+                    Task {
+                        await AppDetectiveApp.installCLI()
+                    }
                 } label: {
                     Label("Install Command Line Tool…", systemImage: "terminal")
                 }
@@ -83,12 +98,18 @@ struct AppDetectiveApp: App {
         }
     }
 
-    static func installCLI() {
+    @MainActor
+    static func installCLI() async {
+        let isOnPath = await CLIInstallerService.isOnPath()
         let alert = NSAlert()
         let wasInstalled = CLIInstallerService.isInstalled()
         if wasInstalled {
             alert.messageText = "Command Line Tool Already Installed"
-            alert.informativeText = "`appdetective` is already available at \(CLIInstallerService.installPath). Reinstall to update the symlink, or remove it."
+            alert.informativeText = if isOnPath {
+                "`appdetective` is already available at \(CLIInstallerService.installPath). Reinstall to update the symlink, or remove it."
+            } else {
+                "`appdetective` is linked at \(CLIInstallerService.installPath), but the directory is not in your PATH.\n\n\(CLIInstallerService.pathHint)"
+            }
             alert.addButton(withTitle: "Reinstall")
             alert.addButton(withTitle: "Remove")
             alert.addButton(withTitle: "Cancel")
@@ -101,7 +122,7 @@ struct AppDetectiveApp: App {
 
         switch (wasInstalled, alert.runModal()) {
         case (true, .alertFirstButtonReturn), (false, .alertFirstButtonReturn):
-            performInstall()
+            performInstall(isOnPath: isOnPath)
         case (true, .alertSecondButtonReturn):
             performUninstall()
         default:
@@ -109,14 +130,15 @@ struct AppDetectiveApp: App {
         }
     }
 
-    private static func performInstall() {
+    @MainActor
+    private static func performInstall(isOnPath: Bool) {
         do {
             try CLIInstallerService.install()
             let alert = NSAlert()
             alert.messageText = "Command Line Tool Installed"
-            var message = "`appdetective` is now available at \(CLIInstallerService.installPath)."
-            if !CLIInstallerService.isOnPath() {
-                message += "\n\n~/.local/bin is not in your PATH. Add this to your shell config to enable the command:\n\n    export PATH=\"$HOME/.local/bin:$PATH\""
+            var message = "`appdetective` is linked at \(CLIInstallerService.installPath)."
+            if !isOnPath {
+                message += "\n\nThe directory is not in your PATH.\n\n\(CLIInstallerService.pathHint)"
             }
             alert.informativeText = message
             alert.runModal()
@@ -125,6 +147,7 @@ struct AppDetectiveApp: App {
         }
     }
 
+    @MainActor
     private static func performUninstall() {
         do {
             try CLIInstallerService.uninstall()
@@ -137,6 +160,7 @@ struct AppDetectiveApp: App {
         }
     }
 
+    @MainActor
     private static func showErrorAlert(title: String, message: String) {
         let alert = NSAlert()
         alert.alertStyle = .warning
@@ -169,6 +193,7 @@ struct AppDetectiveApp: App {
                 contentViewModel.folderURL = nil
                 contentViewModel.appResults = []
                 contentViewModel.errorMessage = nil
+                contentViewModel.warningMessage = nil
                 contentViewModel.navigationTitle = "Select Folder"
             }
             isResolvingBookmark = false
@@ -193,6 +218,7 @@ struct AppDetectiveApp: App {
             selectedFolderBookmark = nil
             contentViewModel.folderURL = nil
             contentViewModel.errorMessage = "Error resolving bookmark."
+            contentViewModel.warningMessage = nil
             contentViewModel.navigationTitle = "Error"
         }
         isResolvingBookmark = false

--- a/AppDetective/AppDetective/Services/CLIInstallerService.swift
+++ b/AppDetective/AppDetective/Services/CLIInstallerService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Darwin
 
 enum CLIInstallerError: LocalizedError {
     case bundledBinaryMissing
@@ -14,8 +15,21 @@ enum CLIInstallerError: LocalizedError {
     }
 }
 
+private actor CLIPathStatusCache {
+    private var cachedValue: Bool?
+
+    func value() -> Bool? {
+        cachedValue
+    }
+
+    func setValue(_ value: Bool) {
+        cachedValue = value
+    }
+}
+
 struct CLIInstallerService {
     static let toolName = "appdetective"
+    private static let pathStatusCache = CLIPathStatusCache()
 
     static var installDirectory: URL {
         FileManager.default.homeDirectoryForCurrentUser
@@ -28,6 +42,22 @@ struct CLIInstallerService {
     }
 
     static var installPath: String { installURL.path }
+
+    static var pathHint: String {
+        let shell = loginShell
+        if shell.hasSuffix("fish") {
+            return "fish_add_path \(installDirectory.path)"
+        }
+
+        let rcFile = if shell.hasSuffix("zsh") {
+            "~/.zshrc"
+        } else if shell.hasSuffix("bash") {
+            "~/.bash_profile"
+        } else {
+            "~/.profile"
+        }
+        return "Add to \(rcFile):\nexport PATH=\"\(installDirectory.path):$PATH\""
+    }
 
     /// Returns the path to the CLI binary shipped inside the app bundle, if present.
     static func bundledBinaryURL() -> URL? {
@@ -47,8 +77,60 @@ struct CLIInstallerService {
     }
 
     /// Returns true if `~/.local/bin` is already in the user's `PATH`.
-    static func isOnPath() -> Bool {
-        let path = ProcessInfo.processInfo.environment["PATH"] ?? ""
+    static func isOnPath() async -> Bool {
+        if let cachedValue = await pathStatusCache.value() {
+            return cachedValue
+        }
+
+        let path = await loginShellPATH() ?? ProcessInfo.processInfo.environment["PATH"] ?? ""
+        let isOnPath = pathContainsInstallDirectory(path)
+        await pathStatusCache.setValue(isOnPath)
+        return isOnPath
+    }
+
+    static func loginShellPATH() async -> String? {
+        await Task.detached(priority: .userInitiated) {
+            loginShellPATHSync()
+        }.value
+    }
+
+    private static func loginShellPATHSync() -> String? {
+        let shell = loginShell
+        let isFish = shell.hasSuffix("fish")
+        let command = isFish ? "string join : -- $PATH" : "printf %s \"$PATH\""
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: shell)
+        process.arguments = ["-l", "-c", command]
+
+        let outputPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = FileHandle(forWritingAtPath: "/dev/null")
+
+        do {
+            try process.run()
+            let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return nil }
+
+            return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        } catch {
+            return nil
+        }
+    }
+
+    private static var loginShell: String {
+        if let passwordEntry = getpwuid(getuid()),
+           let shell = passwordEntry.pointee.pw_shell,
+           let shellString = String(validatingUTF8: shell),
+           !shellString.isEmpty
+        {
+            return shellString
+        }
+
+        return ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+    }
+
+    private static func pathContainsInstallDirectory(_ path: String) -> Bool {
         let resolved = (installDirectory.path as NSString).standardizingPath
         return path.split(separator: ":").contains { ($0 as NSString).standardizingPath == resolved }
     }

--- a/AppDetective/AppDetective/Services/ScanService.swift
+++ b/AppDetective/AppDetective/Services/ScanService.swift
@@ -1,14 +1,23 @@
 import Foundation
 
 struct ScanService {
+    struct ScanResult {
+        let appURLs: [URL]
+        let skippedDirectoryURLs: [URL]
+
+        var hasSkippedDirectories: Bool {
+            !skippedDirectoryURLs.isEmpty
+        }
+    }
+
     enum ScanError: Error, LocalizedError {
-        case directoryEnumerationFailed(Error)
+        case directoryEnumerationFailed(URL, Error)
         case notADirectory(URL)
 
         var errorDescription: String? {
             switch self {
-            case .directoryEnumerationFailed(let underlyingError):
-                return "Failed to read the contents of the folder: \(underlyingError.localizedDescription)"
+            case .directoryEnumerationFailed(let url, let underlyingError):
+                return "Failed to read the contents of \(url.path): \(underlyingError.localizedDescription)"
             case .notADirectory(let url):
                 return "The selected path is not a folder: \(url.path)"
             }
@@ -20,13 +29,27 @@ struct ScanService {
     /// - Returns: An array of URLs pointing to the found .app bundles.
     /// - Throws: A ScanError if enumeration fails.
     func scan(folderURL: URL) throws -> [URL] {
+        try scanWithDiagnostics(folderURL: folderURL).appURLs
+    }
+
+    /// Scans the given folder URL for .app bundles and reports child folders that could not be read.
+    /// - Parameter folderURL: The URL of the folder to scan. Assumes security scope access has already been started.
+    /// - Returns: A scan result containing found app URLs and skipped child directories.
+    /// - Throws: A ScanError if the selected root folder cannot be scanned.
+    func scanWithDiagnostics(folderURL: URL) throws -> ScanResult {
         var isDir: ObjCBool = false
         guard FileManager.default.fileExists(atPath: folderURL.path, isDirectory: &isDir), isDir.boolValue else {
             throw ScanError.notADirectory(folderURL)
         }
 
         var appURLs: [URL] = []
-        try enumerateAndFindApps(in: folderURL, foundApps: &appURLs)
+        var skippedDirectoryURLs: [URL] = []
+        try enumerateAndFindApps(
+            in: folderURL,
+            foundApps: &appURLs,
+            skippedDirectoryURLs: &skippedDirectoryURLs,
+            isRequiredRoot: true
+        )
 
         // Special case: If scanning /Applications, also scan /System/Applications
         // since macOS Catalina+ stores system apps there
@@ -34,14 +57,24 @@ struct ScanService {
             let systemAppsURL = URL(fileURLWithPath: "/System/Applications")
             var systemIsDir: ObjCBool = false
             if FileManager.default.fileExists(atPath: systemAppsURL.path, isDirectory: &systemIsDir), systemIsDir.boolValue {
-                try enumerateAndFindApps(in: systemAppsURL, foundApps: &appURLs)
+                try enumerateAndFindApps(
+                    in: systemAppsURL,
+                    foundApps: &appURLs,
+                    skippedDirectoryURLs: &skippedDirectoryURLs,
+                    isRequiredRoot: false
+                )
             }
         }
 
-        return appURLs
+        return ScanResult(appURLs: appURLs, skippedDirectoryURLs: skippedDirectoryURLs)
     }
 
-    private func enumerateAndFindApps(in directoryURL: URL, foundApps: inout [URL]) throws {
+    private func enumerateAndFindApps(
+        in directoryURL: URL,
+        foundApps: inout [URL],
+        skippedDirectoryURLs: inout [URL],
+        isRequiredRoot: Bool
+    ) throws {
         let fileManager = FileManager.default
         do {
             let contents = try fileManager.contentsOfDirectory(at: directoryURL, includingPropertiesForKeys: [.isDirectoryKey], options: [])
@@ -61,11 +94,19 @@ struct ScanService {
                 if itemURL.pathExtension.lowercased() == "app" {
                     foundApps.append(itemURL)
                 } else {
-                    try enumerateAndFindApps(in: itemURL, foundApps: &foundApps)
+                    try enumerateAndFindApps(
+                        in: itemURL,
+                        foundApps: &foundApps,
+                        skippedDirectoryURLs: &skippedDirectoryURLs,
+                        isRequiredRoot: false
+                    )
                 }
             }
         } catch {
-            throw ScanError.directoryEnumerationFailed(error)
+            if isRequiredRoot {
+                throw ScanError.directoryEnumerationFailed(directoryURL, error)
+            }
+            skippedDirectoryURLs.append(directoryURL)
         }
     }
 }

--- a/AppDetective/AppDetective/ViewModels/ContentViewModel.swift
+++ b/AppDetective/AppDetective/ViewModels/ContentViewModel.swift
@@ -9,6 +9,7 @@ class ContentViewModel: ObservableObject {
     @Published var totalAppsToScan: Int = 0
     @Published var appResults: [AppInfo] = []
     @Published var errorMessage: String? = nil
+    @Published var warningMessage: String? = nil
     @Published var navigationTitle: String = Constants.AppName
     @Published var folderURL: URL? = nil
     @Published var metadataLoadProgress: Double = 0.0
@@ -96,6 +97,7 @@ class ContentViewModel: ObservableObject {
         sizeCache.removeAll()
         appResults.removeAll()
         errorMessage = nil
+        warningMessage = nil
         scanProgress = 0.0
         metadataLoadProgress = 0.0
         totalMetadataItems = 0
@@ -131,6 +133,7 @@ class ContentViewModel: ObservableObject {
     func scanApplications() async {
         guard let currentFolderURL = folderURL else {
             errorMessage = "No folder selected."
+            warningMessage = nil
             navigationTitle = "No Folder"
             appResults = []
             isLoading = false
@@ -139,6 +142,7 @@ class ContentViewModel: ObservableObject {
 
         appResults = []
         errorMessage = nil
+        warningMessage = nil
         isLoading = true
         scanProgress = 0.0
         totalAppsToScan = 0
@@ -147,21 +151,25 @@ class ContentViewModel: ObservableObject {
         var detectedApps: [AppInfo] = []
 
         do {
-            guard currentFolderURL.startAccessingSecurityScopedResource() else {
-                errorMessage = "Could not access the selected folder. Please reselect."
-                isLoading = false
-                scanProgress = 0.0
-                totalAppsToScan = 0
-                navigationTitle = "Error Accessing Folder"
-                return
+            let isSecurityScoped = currentFolderURL.startAccessingSecurityScopedResource()
+            defer {
+                if isSecurityScoped {
+                    currentFolderURL.stopAccessingSecurityScopedResource()
+                }
             }
 
-            defer { currentFolderURL.stopAccessingSecurityScopedResource() }
-
-            let allAppURLs = try scanService.scan(folderURL: currentFolderURL)
+            let scanResult = try scanService.scanWithDiagnostics(folderURL: currentFolderURL)
+            let allAppURLs = scanResult.appURLs
+            if scanResult.hasSkippedDirectories {
+                warningMessage = "Some folders could not be scanned due to permissions."
+            }
             totalAppsToScan = allAppURLs.count
             guard totalAppsToScan > 0 else {
-                errorMessage = "No applications found in the selected folder."
+                errorMessage = if scanResult.hasSkippedDirectories {
+                    "No applications found in the selected folder. Some folders could not be scanned due to permissions."
+                } else {
+                    "No applications found in the selected folder."
+                }
                 isLoading = false
                 navigationTitle = "No Apps Found"
                 return
@@ -199,10 +207,12 @@ class ContentViewModel: ObservableObject {
 
         } catch let error as ScanService.ScanError {
             errorMessage = error.localizedDescription
+            warningMessage = nil
             navigationTitle = "Scan Error"
             isLoading = false
         } catch {
             errorMessage = "An unexpected error occurred: \(error.localizedDescription)"
+            warningMessage = nil
             navigationTitle = "Unexpected Error"
             isLoading = false
         }

--- a/AppDetective/AppDetective/Views/ContentView.swift
+++ b/AppDetective/AppDetective/Views/ContentView.swift
@@ -13,6 +13,7 @@ struct ContentView: View {
     var body: some View {
         let isLoading = viewModel.isLoading
         let errorMessage = viewModel.errorMessage
+        let warningMessage = viewModel.warningMessage
 
         NavigationSplitView {
             if #available(macOS 15.0, *) {
@@ -32,7 +33,19 @@ struct ContentView: View {
                         Text("Error: \(msg)")
                             .foregroundColor(.red)
                             .padding()
+                            .accessibilityIdentifier("scan-error-message")
                     } else {
+                        if let warningMessage {
+                            Text(warningMessage)
+                                .font(.caption)
+                                .foregroundColor(.orange)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 8)
+                                .background(Color.orange.opacity(0.12))
+                                .accessibilityIdentifier("scan-warning-message")
+                        }
+
                         if viewModel.appResults.isEmpty && !isLoading {
                             Text("No apps found or scan not started.")
                                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/AppDetective/AppDetectiveUITests/AppDetectiveUITests.swift
+++ b/AppDetective/AppDetectiveUITests/AppDetectiveUITests.swift
@@ -1,0 +1,52 @@
+import XCTest
+
+final class AppDetectiveUITests: XCTestCase {
+    private var scanFolderURL: URL?
+    private var protectedFolderURL: URL?
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+
+        let folderURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AppDetectiveUITests_\(UUID().uuidString)", isDirectory: true)
+        let readableAppURL = folderURL.appendingPathComponent("Readable.app", isDirectory: true)
+        let protectedURL = folderURL.appendingPathComponent("Adobe Creative Cloud", isDirectory: true)
+
+        try FileManager.default.createDirectory(at: readableAppURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: protectedURL, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: protectedURL.path)
+
+        scanFolderURL = folderURL
+        protectedFolderURL = protectedURL
+    }
+
+    override func tearDownWithError() throws {
+        if let protectedFolderURL {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: protectedFolderURL.path)
+        }
+
+        if let scanFolderURL {
+            try? FileManager.default.removeItem(at: scanFolderURL)
+        }
+    }
+
+    func testPermissionDeniedFolderDoesNotBlockReadableApps() throws {
+        let scanFolderURL = try XCTUnwrap(scanFolderURL)
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-ApplePersistenceIgnoreState",
+            "YES",
+            "--scan-folder",
+            scanFolderURL.path
+        ]
+
+        app.launch()
+        app.activate()
+
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 5), app.debugDescription)
+
+        XCTAssertTrue(app.staticTexts["Readable"].waitForExistence(timeout: 15), app.debugDescription)
+        XCTAssertTrue(app.staticTexts["scan-warning-message"].waitForExistence(timeout: 5), app.debugDescription)
+        XCTAssertFalse(app.staticTexts["scan-error-message"].exists, app.debugDescription)
+    }
+}

--- a/AppDetective/project.yml
+++ b/AppDetective/project.yml
@@ -16,11 +16,11 @@ packages:
 
 settings:
     base:
-        CURRENT_PROJECT_VERSION: 6
+        CURRENT_PROJECT_VERSION: 7
         DEAD_CODE_STRIPPING: YES
         DEVELOPMENT_TEAM: V28VJH6B6S
         ENABLE_USER_SCRIPT_SANDBOXING: YES
-        MARKETING_VERSION: 1.4.0
+        MARKETING_VERSION: 1.4.1
         STRING_CATALOG_GENERATE_SYMBOLS: YES
 
 targets:
@@ -96,6 +96,20 @@ targets:
                 GENERATE_INFOPLIST_FILE: YES
                 PRODUCT_BUNDLE_IDENTIFIER: dev.hewig.AppDetectiveTests
                 TEST_HOST: "$(BUILT_PRODUCTS_DIR)/AppDetective.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/AppDetective"
+    AppDetectiveUITests:
+        type: bundle.ui-testing
+        platform: macOS
+        deploymentTarget: "14.6"
+        sources:
+            - path: AppDetectiveUITests
+        dependencies:
+            - target: AppDetective
+        settings:
+            base:
+                DEAD_CODE_STRIPPING: YES
+                GENERATE_INFOPLIST_FILE: YES
+                PRODUCT_BUNDLE_IDENTIFIER: dev.hewig.AppDetectiveUITests
+                TEST_TARGET_NAME: AppDetective
 
 schemes:
     appdetective-cli:
@@ -116,6 +130,7 @@ schemes:
             config: Debug
             targets:
                 - AppDetectiveTests
+                - AppDetectiveUITests
         analyze:
             config: Debug
         archive:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ App Detective ships with `appdetective`, a CLI for analyzing a single `.app` bun
 
 Install it from inside the app: **App Detective → Install Command Line Tool…** symlinks `appdetective` into `~/.local/bin/`. If `~/.local/bin` isn't on your `PATH`, the install dialog tells you the line to add.
 
+You can also start the app directly on a folder:
+
+```bash
+open -a "App Detective" --args --scan-folder /Applications
+```
+
 ```bash
 $ appdetective /Applications/Visual\ Studio\ Code.app
 App:        Visual Studio Code.app


### PR DESCRIPTION
## Summary
- skip unreadable child folders during app scans and show a non-fatal warning
- add a macOS UI test that covers an unreadable folder next to a readable app
- add a reusable `--scan-folder` startup option and document it
- improve CLI installer PATH detection by checking the login shell, and simplify the fish hint
- bump AppDetective to 1.4.1 build 7

## Validation
- `just test`
- `just release-dry-run 1.4.1`
- CI passed on the branch before the version bump; this push will run CI again

## Notes
This PR is draft while the 1.4.1 dry-run build is tested on a standard non-admin macOS user account.